### PR TITLE
Add unit tests for nutrition timezone handling, gallery picker, camera crop errors, navigation items, and architecture constraints

### DIFF
--- a/database/services/__tests__/NutritionService.test.ts
+++ b/database/services/__tests__/NutritionService.test.ts
@@ -227,6 +227,28 @@ describe('NutritionService.copyNutritionLogsPreservingMealType', () => {
     expect(copiedBreakfast).not.toBe(copiedDinner);
   });
 
+  it('preserves the source wall-clock time when its stored timezone differs from the target', async () => {
+    const { created } = captureCreatedRecords();
+    // 18:45 in India is 13:15 UTC. Reading the instant directly would therefore
+    // copy the wrong time-of-day onto the target date.
+    const source = mockLog({
+      date: Date.UTC(2026, 6, 14, 13, 15),
+      timezone: '+05:30',
+    });
+
+    await NutritionService.copyNutritionLogsPreservingMealType(
+      [source],
+      new Date(2026, 7, 1)
+    );
+
+    const copiedWallClock = wallClockDateInTimezone(
+      created[0].date as number,
+      created[0].timezone as string
+    );
+    expect(copiedWallClock.getHours()).toBe(18);
+    expect(copiedWallClock.getMinutes()).toBe(45);
+  });
+
   it('returns the number of logs created and refreshes the widget', async () => {
     captureCreatedRecords();
 
@@ -294,12 +316,35 @@ describe('NutritionService.getRecentLoggedDays', () => {
     expect(days[1].dayKey).toBeGreaterThan(days[2].dayKey);
   });
 
+  it('buckets an instant by each log stored timezone rather than the device timezone', async () => {
+    const instant = Date.UTC(2026, 7, 2, 0, 30);
+    withLogs([
+      mockLog({ id: 'east', date: instant, timezone: '+02:00', calories: 100 }),
+      mockLog({ id: 'west', date: instant, timezone: '-02:00', calories: 200 }),
+    ]);
+
+    const days = await NutritionService.getRecentLoggedDays();
+
+    expect(days).toEqual([
+      { dayKey: Date.UTC(2026, 7, 2), itemCount: 1, calories: 100 },
+      { dayKey: Date.UTC(2026, 7, 1), itemCount: 1, calories: 200 },
+    ]);
+  });
+
   it('respects the limit', async () => {
-    withLogs([logDaysAgo(1, 'a'), logDaysAgo(2, 'b'), logDaysAgo(3, 'c'), logDaysAgo(4, 'd')]);
+    const included = [logDaysAgo(1, 'a'), logDaysAgo(2, 'b')];
+    const omitted = [logDaysAgo(3, 'c'), logDaysAgo(4, 'd')];
+    withLogs([...included, ...omitted]);
 
     const days = await NutritionService.getRecentLoggedDays(2);
 
     expect(days).toHaveLength(2);
+    for (const log of included) {
+      expect(log.getNutrients).toHaveBeenCalledTimes(1);
+    }
+    for (const log of omitted) {
+      expect(log.getNutrients).not.toHaveBeenCalled();
+    }
   });
 
   it('omits the excluded day so the target day never offers to copy itself', async () => {
@@ -312,6 +357,7 @@ describe('NutritionService.getRecentLoggedDays', () => {
 
     expect(days).toHaveLength(1);
     expect(days[0].dayKey).not.toBe(utcNormalizedDayKey(excluded.date, excluded.timezone));
+    expect(excluded.getNutrients).not.toHaveBeenCalled();
   });
 
   it('returns nothing when no days have logs', async () => {

--- a/hooks/__tests__/useCameraCaptureFlow.test.ts
+++ b/hooks/__tests__/useCameraCaptureFlow.test.ts
@@ -94,6 +94,16 @@ describe('useCameraCaptureFlow', () => {
       expect(mockShowSnackbar).toHaveBeenCalledWith('error', 'food.aiCamera.cameraError');
     });
 
+    it('shows the camera-error snackbar when cropping a captured image fails', async () => {
+      mockOpenCropperAsync.mockRejectedValue(new Error('crop failed'));
+      const { result, process } = renderFlow();
+
+      await result.current.takePicture();
+
+      expect(process).not.toHaveBeenCalled();
+      expect(mockShowSnackbar).toHaveBeenCalledWith('error', 'food.aiCamera.cameraError');
+    });
+
     it('is a no-op while the camera ref is unset', async () => {
       const { result, process } = renderFlow({ cameraRef: { current: null } });
 
@@ -140,6 +150,16 @@ describe('useCameraCaptureFlow', () => {
 
       await result.current.pickFromGallery();
 
+      expect(mockShowSnackbar).toHaveBeenCalledWith('error', 'food.aiCamera.cameraError');
+    });
+
+    it('shows the camera-error snackbar when cropping the picked image fails', async () => {
+      mockOpenCropperAsync.mockRejectedValue(new Error('crop failed'));
+      const { result, process } = renderFlow();
+
+      await result.current.pickFromGallery();
+
+      expect(process).not.toHaveBeenCalled();
       expect(mockShowSnackbar).toHaveBeenCalledWith('error', 'food.aiCamera.cameraError');
     });
 

--- a/hooks/__tests__/useNavigationItems.test.ts
+++ b/hooks/__tests__/useNavigationItems.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { NAV_ITEM_KEYS, type NavItemKey } from '@/constants/settings';
+import { SettingsService } from '@/database/services/SettingsService';
+import { useMenstrualCycle } from '@/hooks/useMenstrualCycle';
+import { isNavItemAvailable, useNavigationItems } from '@/hooks/useNavigationItems';
+import { useSettings } from '@/hooks/useSettings';
+
+jest.mock('../../hooks/useSettings');
+jest.mock('../../hooks/useMenstrualCycle');
+jest.mock('../../database/services/SettingsService', () => ({
+  SettingsService: {
+    setNavSlot: jest.fn(),
+    swapNavSlots: jest.fn(),
+  },
+}));
+
+const mockUseSettings = jest.mocked(useSettings);
+const mockUseMenstrualCycle = jest.mocked(useMenstrualCycle);
+const mockSettingsService = jest.mocked(SettingsService);
+
+function configure({
+  slots = ['workouts', 'food', 'profile'] as const,
+  isCycleActive = false,
+}: {
+  slots?: readonly [NavItemKey, NavItemKey, NavItemKey];
+  isCycleActive?: boolean;
+} = {}) {
+  mockUseSettings.mockReturnValue({
+    isAiConfigured: true,
+    navSlot1: slots[0],
+    navSlot2: slots[1],
+    navSlot3: slots[2],
+  } as ReturnType<typeof useSettings>);
+  mockUseMenstrualCycle.mockReturnValue({ isActive: isCycleActive } as ReturnType<
+    typeof useMenstrualCycle
+  >);
+}
+
+describe('useNavigationItems', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configure();
+  });
+
+  it('returns configured slots unchanged when all destinations are available', () => {
+    const { result } = renderHook(() => useNavigationItems());
+
+    expect(result.current.rawSlots).toEqual({ 1: 'workouts', 2: 'food', 3: 'profile' });
+    expect(result.current.isAiConfigured).toBe(true);
+    expect(result.current.isCycleActive).toBe(false);
+  });
+
+  it('keeps the cycle destination when cycle tracking is active', () => {
+    configure({ slots: ['cycle', 'food', 'profile'], isCycleActive: true });
+
+    const { result } = renderHook(() => useNavigationItems());
+
+    expect(result.current.rawSlots).toEqual({ 1: 'cycle', 2: 'food', 3: 'profile' });
+  });
+
+  it('replaces an unavailable cycle slot with the first unused fallback', () => {
+    configure({ slots: ['cycle', 'workouts', 'food'] });
+
+    const { result } = renderHook(() => useNavigationItems());
+
+    expect(result.current.rawSlots).toEqual({ 1: 'profile', 2: 'workouts', 3: 'food' });
+  });
+
+  it('persists a destination that is not already assigned', async () => {
+    const { result } = renderHook(() => useNavigationItems());
+
+    await act(() => result.current.setNavSlot(2, 'settings'));
+
+    expect(mockSettingsService.setNavSlot).toHaveBeenCalledWith(2, 'settings');
+    expect(mockSettingsService.swapNavSlots).not.toHaveBeenCalled();
+  });
+
+  it('atomically swaps when the selected destination is assigned to another slot', async () => {
+    const { result } = renderHook(() => useNavigationItems());
+
+    await act(() => result.current.setNavSlot(3, 'workouts'));
+
+    expect(mockSettingsService.swapNavSlots).toHaveBeenCalledWith(3, 'workouts', 1, 'profile');
+    expect(mockSettingsService.setNavSlot).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest slots after a rerender when deciding how to swap', async () => {
+    const { result, rerender } = renderHook(() => useNavigationItems());
+    configure({ slots: ['settings', 'food', 'workouts'] });
+    rerender();
+
+    await act(() => result.current.setNavSlot(1, 'workouts'));
+
+    expect(mockSettingsService.swapNavSlots).toHaveBeenCalledWith(1, 'workouts', 3, 'settings');
+  });
+});
+
+describe('isNavItemAvailable', () => {
+  it('only gates the cycle destination when cycle tracking is inactive', () => {
+    expect(NAV_ITEM_KEYS.filter((item) => !isNavItemAvailable(item, false))).toEqual(['cycle']);
+  });
+
+  it('allows every destination when cycle tracking is active', () => {
+    expect(NAV_ITEM_KEYS.every((item) => isNavItemAvailable(item, true))).toBe(true);
+  });
+});

--- a/utils/__tests__/galleryImagePicker.test.ts
+++ b/utils/__tests__/galleryImagePicker.test.ts
@@ -54,6 +54,21 @@ describe('pickImageFromGallery', () => {
 
     await expect(pickImageFromGallery()).resolves.toBeNull();
   });
+
+  it('returns null when the picker omits its assets collection', async () => {
+    mockLaunchImageLibrary.mockResolvedValue({ canceled: false });
+
+    await expect(pickImageFromGallery()).resolves.toBeNull();
+  });
+
+  it('returns the first asset when the picker supplies multiple images', async () => {
+    mockLaunchImageLibrary.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///first.jpg' }, { uri: 'file:///second.jpg' }],
+    });
+
+    await expect(pickImageFromGallery()).resolves.toBe('file:///first.jpg');
+  });
 });
 
 describe('pickAndCropImageFromGallery', () => {
@@ -95,5 +110,40 @@ describe('pickAndCropImageFromGallery', () => {
     mockOpenCropperAsync.mockResolvedValue(null);
 
     await expect(pickAndCropImageFromGallery()).resolves.toBeNull();
+  });
+
+  it('uses the documented default crop quality', async () => {
+    mockLaunchImageLibrary.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///picked.jpg' }],
+    });
+    mockOpenCropperAsync.mockResolvedValue({ path: 'file:///cropped.jpg' });
+
+    await pickAndCropImageFromGallery();
+
+    expect(mockOpenCropperAsync).toHaveBeenCalledWith({
+      imageUri: 'file:///picked.jpg',
+      format: 'jpeg',
+      compressImageQuality: 0.8,
+    });
+  });
+
+  it('propagates picker failures to the caller', async () => {
+    const error = new Error('picker failed');
+    mockLaunchImageLibrary.mockRejectedValue(error);
+
+    await expect(pickAndCropImageFromGallery()).rejects.toBe(error);
+    expect(mockOpenCropperAsync).not.toHaveBeenCalled();
+  });
+
+  it('propagates crop failures to the caller', async () => {
+    const error = new Error('crop failed');
+    mockLaunchImageLibrary.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///picked.jpg' }],
+    });
+    mockOpenCropperAsync.mockRejectedValue(error);
+
+    await expect(pickAndCropImageFromGallery()).rejects.toBe(error);
   });
 });

--- a/utils/__tests__/galleryImagePickerArchitecture.test.ts
+++ b/utils/__tests__/galleryImagePickerArchitecture.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join, relative } from 'path';
+
+const repositoryRoot = join(__dirname, '..', '..');
+const ignoredDirectories = new Set([
+  '.expo',
+  '.git',
+  'android',
+  'coverage',
+  'dist',
+  'ios',
+  'node_modules',
+]);
+
+function productionTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (
+        entry.name === '__tests__' ||
+        entry.name.startsWith('.') ||
+        ignoredDirectories.has(entry.name)
+      ) {
+        return [];
+      }
+      return productionTypeScriptFiles(path);
+    }
+
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [path] : [];
+  });
+}
+
+function source(path: string): string {
+  return readFileSync(join(repositoryRoot, path), 'utf8');
+}
+
+describe('gallery picker architecture', () => {
+  const productionFiles = productionTypeScriptFiles(repositoryRoot);
+
+  it('keeps expo-image-picker access behind the shared gallery picker', () => {
+    const filesUsingExpoImagePicker = productionFiles
+      .filter((path) =>
+        /(?:from\s+|require\()['"]expo-image-picker['"]/.test(
+          source(relative(repositoryRoot, path))
+        )
+      )
+      .map((path) => relative(repositoryRoot, path));
+
+    expect(filesUsingExpoImagePicker).toEqual(['utils/galleryImagePicker.ts']);
+  });
+
+  it('does not restore permission prompts or the legacy document picker', () => {
+    const pickerSource = source('utils/galleryImagePicker.ts');
+
+    expect(pickerSource).not.toContain('requestMediaLibraryPermissionsAsync');
+    expect(pickerSource).not.toMatch(/legacy\s*:\s*true/);
+  });
+
+  it.each([
+    'components/modals/CoachModal.tsx',
+    'components/modals/CreateCustomFoodModal.tsx',
+    'components/modals/CreateExerciseModal.tsx',
+    'components/modals/CreateMealModal.tsx',
+  ])('%s picks and crops through the shared high-level helper', (path) => {
+    const componentSource = source(path);
+
+    expect(componentSource).toContain(
+      "import { pickAndCropImageFromGallery } from '@/utils/galleryImagePicker';",
+    );
+    expect(componentSource).toMatch(/await pickAndCropImageFromGallery\(\)/);
+  });
+
+  it('keeps the camera flow on the instrumented low-level picker and crop steps', () => {
+    const hookSource = source('hooks/useCameraCaptureFlow.ts');
+
+    expect(hookSource).toContain(
+      "import { pickImageFromGallery } from '@/utils/galleryImagePicker';",
+    );
+    expect(hookSource).toMatch(/await pickImageFromGallery\(\)/);
+    expect(hookSource).toMatch(/await openCropperAsync\(/);
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve confidence around timezone-sensitive nutrition copy and bucketing logic. 
- Ensure image-picking and cropping paths surface errors correctly and adhere to documented defaults. 
- Validate navigation slot management logic and atomic swaps when reassigning destinations. 
- Enforce architecture constraints that keep `expo-image-picker` usage behind the shared gallery helper.

### Description

- Added tests to `NutritionService.test.ts` that verify wall-clock preservation when source timezones differ from the target, bucketing by each log's stored timezone, and that nutrient lookups are only performed for included days or omitted when excluding a day. 
- Extended `useCameraCaptureFlow.test.ts` to assert that cropping failures (both for captured and picked images) produce the camera-error snackbar and prevent further processing. 
- Added `useNavigationItems.test.ts` to exercise `useNavigationItems` behavior including availability gating for cycle tracking, setting/swapping nav slots, and ensuring the latest slots are used on rerender. 
- Expanded `galleryImagePicker.test.ts` to cover missing/empty asset collections, multiple returned assets, documented default crop quality, and propagation of picker/crop failures. 
- Introduced `galleryImagePickerArchitecture.test.ts` to assert that `expo-image-picker` is only used in `utils/galleryImagePicker.ts`, that the shared helper is used by UI modals, and that camera flows still use the low-level picker + crop steps.

### Testing

- Ran the Jest unit test suite for the modified and added tests (`hooks`, `utils`, `database/services` tests); all new and updated tests passed. 
- Verified the architecture assertions and error-propagation tests under the unit test runner with no failures. 
- No integration or e2e tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7511533b98832f97229eb153119bb6)